### PR TITLE
Lets live dangerously: updated gerber-to-svg to v4.2.8 

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/tracespace/pcb-stackup-core",
   "peerDependencies": {
-    "gerber-to-svg": "^2.0.0",
+    "gerber-to-svg": "^4.2.8",
     "whats-that-gerber": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
It doesn't break anything on my dev instance. 
Related: https://github.com/MacroFab/pcb-stackup/pull/3