### PR TITLE
MFP2-2047: Fix Incorrect rendering of empty soldermask files

### DIFF
--- a/lib/sort-layers.js
+++ b/lib/sort-layers.js
@@ -17,9 +17,7 @@ function acceptLayer(layer) {
     layer != null &&
     layer.type != null &&
     layer.side != null &&
-    layer.converter != null &&
-    layer.converter.layer != null &&
-    layer.converter.layer.length
+    layer.converter != null
   )
 }
 

--- a/lib/stack-layers.js
+++ b/lib/stack-layers.js
@@ -62,28 +62,27 @@ module.exports = function(
      layer.push(useLayer(element, cuLayerId, classPrefix + 'cf', cfMaskId))
   }
 
+
   // add soldermask and silkscreen
   // silkscreen will not be added if no soldermask, because that's how it works in RL
   for (var i = 0; i < smLayers.length; i++) {
-    var smLayerId = smLayers[i]
-    // solder mask is... a mask, so mask it
-    var smMaskId = idPrefix + 'sm-mask_' + (i + 1)
-    var smMaskShape = [
-      createRect(element, box, '#fff'),
-      useLayer(element, smLayerId),
-    ]
-    var smMaskGroupAtrr = {fill: '#000', stroke: '#000'}
-    var smMaskGroup = [element('g', smMaskGroupAtrr, smMaskShape)]
+    var smLayerId = smLayers[i];
+    var smMaskId = idPrefix + 'sm-mask_' + (i + 1);
 
-    defs.push(element('mask', {id: smMaskId}, smMaskGroup))
+    var maskBase = createRect(element, box, '#fff');
 
-    // add the layer that gets masked
-    var smGroupAttr = {mask: 'url(#' + smMaskId + ')'}
+    var cutoutShapes = [useLayer(element, smLayerId)];
+    var cutoutGroupAttr = {fill: '#000', stroke: '#000'};
+    var cutoutGroup = element('g', cutoutGroupAttr, cutoutShapes);
+
+    var maskChildren = [maskBase, cutoutGroup];
+    defs.push(element('mask', {id: smMaskId}, maskChildren));
+
+    var smGroupAttr = {mask: 'url(#' + smMaskId + ')'};
     var smGroupShape = [
-      createRect(element, box, 'currentColor', classPrefix + 'sm'),
-    ]
-
-    layer.push(element('g', smGroupAttr, smGroupShape))
+        createRect(element, box, 'currentColor', classPrefix + 'sm'),
+    ];
+    layer.push(element('g', smGroupAttr, smGroupShape));
   }
 
   if (smLayers.length) {


### PR DESCRIPTION
We also need to bump s3-png-generator.js which is what actually uses this package to do the composite.
Ticket: https://macrofab.atlassian.net/browse/MFP2-2047